### PR TITLE
Show correct XP info (#2)

### DIFF
--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
@@ -48,7 +48,6 @@ simulated function UIButton SetDisabled(bool disabled, optional string TooltipTe
 simulated function string GetPromotionProgress(XComGameState_Unit Unit)
 {
 	local string promoteProgress;
-	local int NumKills;
 	local X2SoldierClassTemplate ClassTemplate;
 
 	if (Unit.IsSoldier())
@@ -71,10 +70,10 @@ simulated function string GetPromotionProgress(XComGameState_Unit Unit)
 	}
 	else
 	{
-		// Deduct the existing assists contribution before multiplying by KillAssistsPerKill.
-		// Ignoring psi credits as they appear not to be used at all.
-		NumKills = Unit.GetTotalNumKills() - Round(Unit.KillAssistsCount) / ClassTemplate.KillAssistsPerKill;
-		promoteProgress = NumKills * ClassTemplate.KillAssistsPerKill + int(Unit.KillAssistsCount) $
+		// GetTotalNumKills() includes the contribution from kill assists (and psi credits,
+		// but ignoring those as they appear not to be used at all). We then need to add the
+		// remainder from kill assist count that's not included in GetTotalNumKills().
+		promoteProgress = Unit.GetTotalNumKills() * ClassTemplate.KillAssistsPerKill  + (Unit.KillAssistsCount % ClassTemplate.KillAssistsPerKill) $
 				"/" $ class'X2ExperienceConfig'.static.GetRequiredKills(Unit.GetSoldierRank() + 1) * ClassTemplate.KillAssistsPerKill;
 	}
 

--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
@@ -47,7 +47,6 @@ simulated function UIButton SetDisabled(bool disabled, optional string TooltipTe
 simulated function string GetPromotionProgress(XComGameState_Unit Unit)
 {
 	local string promoteProgress;
-	local int NumKills;
 	local X2SoldierClassTemplate ClassTemplate;
 
 	if (Unit.IsSoldier())
@@ -64,24 +63,7 @@ simulated function string GetPromotionProgress(XComGameState_Unit Unit)
 		return "";
 	}
 
-	NumKills = Round(Unit.KillCount * ClassTemplate.KillAssistsPerKill);
-
-	// Increase kills for WetWork bonus if appropriate - DEPRECATED
-	NumKills += Round(Unit.WetWorkKills * class'X2ExperienceConfig'.default.NumKillsBonus * ClassTemplate.KillAssistsPerKill);
-
-	// Add in bonus kills
-	NumKills += Round(Unit.BonusKills * ClassTemplate.KillAssistsPerKill);
-
-	//  Add number of kills from assists
-	NumKills += Round(Unit.KillAssistsCount);
-
-	// Add required kills of StartingRank
-	NumKills += class'X2ExperienceConfig'.static.GetRequiredKills(Unit.StartingRank) * ClassTemplate.KillAssistsPerKill;
-
-	// Add Non-tactical kills (from covert actions)
-	NumKills += Unit.NonTacticalKills * ClassTemplate.KillAssistsPerKill;
-
-	promoteProgress = NumKills $ "/" $ class'X2ExperienceConfig'.static.GetRequiredKills(Unit.GetSoldierRank() + 1) * ClassTemplate.KillAssistsPerKill;
+	promoteProgress = Unit.GetTotalNumKills() $ "/" $ class'X2ExperienceConfig'.static.GetRequiredKills(Unit.GetSoldierRank() + 1);
 
 	return class'UIUtilities_Text'.static.InjectImage(class'UIUtilities_Image'.const.HTML_PromotionIcon, 16, 20, -6) $ "</img>" @ promoteProgress;
 }


### PR DESCRIPTION
The XP information now delegates to `XCGS_Unit.GetTotalNumKills()` for maximum compatibility with other mods.

Fixes #2.