### PR TITLE
Support the Community Highlander status hooks (#1)

### DIFF
--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
@@ -339,7 +339,17 @@ simulated function UpdateData()
 	SoldierClass = Unit.GetSoldierClassTemplate();
 	FactionState = Unit.GetResistanceFaction();
 
-	GetPersonnelStatusSeparate(Unit, status, statusTimeLabel, statusTimeValue);
+	if (class'X2DownloadableContentInfo_DetailedSoldierListWOTC'.default.IsRequiredCHLInstalled)
+	{
+		// Use the Community Highlander function so that we work with mods that
+		// use the unit status hooks it provides.
+		class'UIUtilities_Strategy'.static.GetPersonnelStatusSeparate(Unit, status, statusTimeLabel, statusTimeValue);
+	}
+	else
+	{
+		GetPersonnelStatusSeparate(Unit, status, statusTimeLabel, statusTimeValue);
+	}
+
 	mentalStatus = "";
 
 	if(Unit.IsActive())

--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2DownloadableContentInfo_DetailedSoldierListWOTC.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2DownloadableContentInfo_DetailedSoldierListWOTC.uc
@@ -11,6 +11,28 @@
 //---------------------------------------------------------------------------------------
 
 class X2DownloadableContentInfo_DetailedSoldierListWOTC extends X2DownloadableContentInfo;
+
+var config bool IsRequiredCHLInstalled;
+
+// Copied from robojumper's SquadSelect. Checks whether the Community Highlander
+// is active and meets the given minimum version requirement.
+static function bool IsCHLMinVersionInstalled(int iMajor, int iMinor)
+{
+	local X2StrategyElementTemplate VersionTemplate;
+
+	VersionTemplate = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager().FindStrategyElementTemplate('CHXComGameVersion');
+	if (VersionTemplate == none)
+	{
+		return false;
+	}
+	else
+	{
+		// DANGER TERRITORY
+		// if this runs without the CHHL or equivalent installed, it crashes
+		return CHXComGameVersionTemplate(VersionTemplate).MajorVersion > iMajor ||  (CHXComGameVersionTemplate(VersionTemplate).MajorVersion == iMajor && CHXComGameVersionTemplate(VersionTemplate).MinorVersion >= iMinor);
+	}
+}
+
 /// <summary>
 /// This method is run if the player loads a saved game that was created prior to this DLC / Mod being installed, and allows the 
 /// DLC / Mod to perform custom processing in response. This will only be called once the first time a player loads a save that was
@@ -78,7 +100,7 @@ static event OnExitPostMissionSequence()
 /// </summary>
 static event OnPostTemplatesCreated()
 {
-
+	default.IsRequiredCHLInstalled = IsCHLMinVersionInstalled(1, 19);
 }
 
 /// <summary>

--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2DownloadableContentInfo_DetailedSoldierListWOTC.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2DownloadableContentInfo_DetailedSoldierListWOTC.uc
@@ -18,19 +18,9 @@ var config bool IsRequiredCHLInstalled;
 // is active and meets the given minimum version requirement.
 static function bool IsCHLMinVersionInstalled(int iMajor, int iMinor)
 {
-	local X2StrategyElementTemplate VersionTemplate;
-
-	VersionTemplate = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager().FindStrategyElementTemplate('CHXComGameVersion');
-	if (VersionTemplate == none)
-	{
-		return false;
-	}
-	else
-	{
-		// DANGER TERRITORY
-		// if this runs without the CHHL or equivalent installed, it crashes
-		return CHXComGameVersionTemplate(VersionTemplate).MajorVersion > iMajor ||  (CHXComGameVersionTemplate(VersionTemplate).MajorVersion == iMajor && CHXComGameVersionTemplate(VersionTemplate).MinorVersion >= iMinor);
-	}
+	return class'CHXComGameVersionTemplate'.default.MajorVersion > iMajor ||
+		(class'CHXComGameVersionTemplate'.default.MajorVersion == iMajor &&
+		 class'CHXComGameVersionTemplate'.default.MinorVersion >= iMinor);
 }
 
 /// <summary>
@@ -95,12 +85,18 @@ static event OnExitPostMissionSequence()
 
 }
 
+// Added in Community Highlander 1.18, so if this is called, the highlander is
+// guaranteed to be loaded.
+static function OnPreCreateTemplates()
+{
+	default.IsRequiredCHLInstalled = IsCHLMinVersionInstalled(1, 19);
+}
+
 /// <summary>
 /// Called after the Templates have been created (but before they are validated) while this DLC / Mod is installed.
 /// </summary>
 static event OnPostTemplatesCreated()
 {
-	default.IsRequiredCHLInstalled = IsCHLMinVersionInstalled(1, 19);
 }
 
 /// <summary>

--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2EventListener_DetailedSoldierList.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2EventListener_DetailedSoldierList.uc
@@ -9,6 +9,13 @@ static function array<X2DataTemplate> CreateTemplates()
 {
 	local array<X2DataTemplate> Templates;
 
+	// If CHL isn't loaded, break out of this function right away to avoid
+	// UnrealEngine attempting to load classes it doesn't have access to.
+	if (!class'X2DownloadableContentInfo_DetailedSoldierListWOTC'.default.IsRequiredCHLInstalled)
+	{
+		return Templates;
+	}
+
 	Templates.AddItem(CreateStatusListeners());
 
 	return Templates;

--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2EventListener_DetailedSoldierList.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/X2EventListener_DetailedSoldierList.uc
@@ -1,0 +1,73 @@
+// X2EventListener_DetailedSoldierList.uc
+// 
+// A listener template that integrates with Community Highlander events to
+// customize how soldier statuses are displayed.
+//
+class X2EventListener_DetailedSoldierList extends X2EventListener;
+
+static function array<X2DataTemplate> CreateTemplates()
+{
+	local array<X2DataTemplate> Templates;
+
+	Templates.AddItem(CreateStatusListeners());
+
+	return Templates;
+}
+
+static function CHEventListenerTemplate CreateStatusListeners()
+{
+	local CHEventListenerTemplate Template;
+
+	`CREATE_X2TEMPLATE(class'CHEventListenerTemplate', Template, 'SoldierStatusListeners');
+	Template.AddCHEvent('OverridePersonnelStatusTime', OnOverridePersonnelStatusTime, ELD_Immediate);
+	Template.RegisterInStrategy = true;
+
+	return Template;
+}
+
+// Converts Days to Hours if the time left on a soldier status is less than
+// the class'UIPersonnel_SoldierListItemDetailed'.default.NUM_HOURS_TO_DAYS
+// threshold.
+//
+// Note that this requires the `XComLWTuple` source file in Development/SrcOrig
+// in order for this class to compile.
+static function EventListenerReturn OnOverridePersonnelStatusTime(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
+{
+	local XComLWTuple			OverrideTuple;
+	local XComGameState_Unit	UnitState;
+	local int					Hours, Days;
+
+	OverrideTuple = XComLWTuple(EventData);
+	if (OverrideTuple == none)
+	{
+		`REDSCREEN("OverridePersonnelStatusTime event triggered with invalid event data.");
+		return ELR_NoInterrupt;
+	}
+
+	UnitState = XComGameState_Unit(EventSource);
+	if (UnitState == none)
+	{
+		`REDSCREEN("OverridePersonnelStatusTime event triggered with invalid source data.");
+		return ELR_NoInterrupt;
+	}
+
+	Hours = OverrideTuple.Data[2].i;
+	if (Hours < 0 || Hours > 24 * 30 * 12) // Ignore year long missions
+	{
+		OverrideTuple.Data[1].s = "";
+		OverrideTuple.Data[2].i = 0;
+		return ELR_NoInterrupt;
+	}
+
+	if (Hours > class'UIPersonnel_SoldierListItemDetailed'.default.NUM_HOURS_TO_DAYS)
+	{
+		Days = FCeil(float(Hours) / 24.0f);
+		OverrideTuple.Data[1].s = class'UIUtilities_Text'.static.GetDaysString(Days);
+		OverrideTuple.Data[2].i = Days;
+	}
+	else
+	{
+		OverrideTuple.Data[1].s = class'UIUtilities_Text'.static.GetHoursString(Hours);
+		OverrideTuple.Data[2].i = Hours;
+	}
+}


### PR DESCRIPTION
Adds a check for whether the Community Highlander is active and meets the minimum version of 1.19. If that's the case, this change makes the soldier list items use the highlander's `GetPersonnelStatusSeparate()` function for rendering soldiers' statuses.

This makes the mod compatible with any other mod that uses those hooks to add or modify soldier statuses.

Closes #1.