### PR TITLE
Support custom displayed ranks for soldiers (#6)

### DIFF
--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
@@ -342,12 +342,19 @@ simulated function UpdateData()
 	if (class'X2DownloadableContentInfo_DetailedSoldierListWOTC'.default.IsRequiredCHLInstalled)
 	{
 		// Use the Community Highlander function so that we work with mods that
-		// use the unit status hooks it provides.
+		// use the unit status and rank hooks it provides
 		class'UIUtilities_Strategy'.static.GetPersonnelStatusSeparate(Unit, status, statusTimeLabel, statusTimeValue);
+
+		shortRankName = Unit.GetSoldierShortRankName();
+		rankIcon = Unit.GetSoldierRankIcon();
 	}
 	else
 	{
 		GetPersonnelStatusSeparate(Unit, status, statusTimeLabel, statusTimeValue);
+
+		shortRankName = `GET_RANK_ABBRV(Unit.GetRank(), SoldierClass.DataName);
+		//rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
+		rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
 	}
 
 	mentalStatus = "";
@@ -372,20 +379,6 @@ simulated function UpdateData()
 
 	flagIcon = Unit.GetCountryTemplate().FlagImage;
 	classIcon = SoldierClass.IconImage;
-	if (class'X2DownloadableContentInfo_DetailedSoldierListWOTC'.default.IsRequiredCHLInstalled)
-	{
-		// If the Community Highlander is installed, use its functions for
-		// getting the soldier rank information to support mods that provide
-		// custom ranks.
-		shortRankName = Unit.GetSoldierShortRankName();
-		rankIcon = Unit.GetSoldierRankIcon();
-	}
-	else
-	{
-		shortRankName = `GET_RANK_ABBRV(Unit.GetRank(), SoldierClass.DataName);
-		//rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
-		rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
-	}
 
 	// if personnel is not staffed, don't show location
 	if( class'UIUtilities_Strategy'.static.DisplayLocation(Unit) )

--- a/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
+++ b/DetailedSoldierListWOTC/Src/DetailedSoldierListWOTC/Classes/UIPersonnel_SoldierListItemDetailed.uc
@@ -322,7 +322,7 @@ simulated function bool ShouldShowPsi(XComGameState_Unit Unit)
 simulated function UpdateData()
 {
 	local XComGameState_Unit Unit;
-	local string UnitLoc, status, statusTimeLabel, statusTimeValue, classIcon, rankIcon, flagIcon, mentalStatus;
+	local string UnitLoc, status, statusTimeLabel, statusTimeValue, classIcon, shortRankName, rankIcon, flagIcon, mentalStatus;
 	local int iRank, iTimeNum;
 	local X2SoldierClassTemplate SoldierClass;
 	local XComGameState_ResistanceFaction FactionState;
@@ -371,9 +371,21 @@ simulated function UpdateData()
 		statusTimeValue = "---";
 
 	flagIcon = Unit.GetCountryTemplate().FlagImage;
-	//rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
-	rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
 	classIcon = SoldierClass.IconImage;
+	if (class'X2DownloadableContentInfo_DetailedSoldierListWOTC'.default.IsRequiredCHLInstalled)
+	{
+		// If the Community Highlander is installed, use its functions for
+		// getting the soldier rank information to support mods that provide
+		// custom ranks.
+		shortRankName = Unit.GetSoldierShortRankName();
+		rankIcon = Unit.GetSoldierRankIcon();
+	}
+	else
+	{
+		shortRankName = `GET_RANK_ABBRV(Unit.GetRank(), SoldierClass.DataName);
+		//rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
+		rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
+	}
 
 	// if personnel is not staffed, don't show location
 	if( class'UIUtilities_Strategy'.static.DisplayLocation(Unit) )
@@ -445,7 +457,7 @@ simulated function UpdateData()
 
 	AS_UpdateDataSoldier(Caps(Unit.GetName(eNameType_Full)),
 					Caps(Unit.GetName(eNameType_Nick)),
-					Caps(`GET_RANK_ABBRV(Unit.GetRank(), SoldierClass.DataName)),
+					Caps(shortRankName),
 					rankIcon,
 					Caps(SoldierClass != None ? SoldierClass.DisplayName : ""),
 					classIcon,


### PR DESCRIPTION
The soldier list item `UpdateData()` function now checks whether the Community Highlander is installed, and if so, uses its functions to get the appropriate displayed rank and icon for the soldier.

I have tested this against Long War of the Chosen (with the community highlander) and vanilla WOTC (without the CHL).

Resolves #6.